### PR TITLE
Stöd för blåbärshjälprebusar

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ stjälprebusarna och ett totalresult efter lunchen.
 Rebusar
 -------
 
-Rebusar ska ha filnamn `Rn.txt`, `Hn.txt`, `Bn.txt`, `Xn.txt` eller `Sn.txt` för vanliga rebusar,
-hjälprebusar, blåbärsrebusar, bonusrebusar eller stjälprebusar, där n är numret på rebusen. För att göra
+Rebusar ska ha filnamn `Rn.txt`, `Hn.txt`, `Bn.txt`, `Jn.txt`, `Xn.txt` eller `Sn.txt` för vanliga rebusar,
+hjälprebusar, blåbärsrebusar, blåbärshjälprebusar, bonusrebusar eller stjälprebusar, där n är numret på rebusen. För att göra
 alternativlösningar kan man byta ut siffran mot valfri text och sedan använda
 t.ex. '*solution*S<text>' som beskrivs ovan.
 
@@ -204,7 +204,11 @@ Blåbärs-rebusar visas bara om de är med i arrayen bluerebus. Exempel:
 
 $bluerebus = array(2, 3, 4, 6, 7, 8);
 
-Vill man inte ha några blåbärsrebusar gör man en tom array.
+Blåbärshjälprebusar visas bara om de är med i arrayen bluehelprebus. Exempel:
+
+$bluehelprebus = array(2, 3);
+
+Vill man inte ha några blåbärsrebusar gör man två tomma arrayer.
 
 I rebusfilerna kan man använda dessa taggar:
 

--- a/present_setup.php
+++ b/present_setup.php
@@ -57,6 +57,9 @@ foreach ($parts as $part => $data) {
                         array_push($actions, new SolutionSlide('B', $n));
                     }
                     array_push($actions, new SolutionSlide('H', $n));
+                    if (in_array($n, $GLOBALS['bluehelprebus'])) {
+                        array_push($actions, new SolutionSlide('J', $n));
+                    }
                     array_push($actions, new EventSlide($eventName, $e));
                 }
                 elseif (preg_match('/^S ([0-9]+)/', $e, $matches)) {

--- a/slide.php
+++ b/slide.php
@@ -205,6 +205,9 @@ class SolutionSlide extends Slide
         elseif ($type == 'B') {
             $this->title = "Blåbärsrebus " . $nr;
         }
+        elseif ($type == 'J') {
+            $this->title = "Blåbärshjälprebus " . $nr;
+        }
         elseif ($type == 'H') {
             $this->title = "Hjälp " . $nr;
         }


### PR DESCRIPTION
Lägger till en ny rebustyp "J" för blåbärshjälprebusar.

Fungerar på samma sätt som blåbärsrebusar: om de existerar definieras de i en global array som ska heta 'bluehelprebus'.